### PR TITLE
Update publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: "build"
 on:
   workflow_dispatch:
   push:
+    branches-ignore:
+      - release
 
 jobs:
   build-tauri:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,8 +58,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
-          releaseName: "App v__VERSION__"
+          releaseName: "Quilter v__VERSION__"
           releaseBody: "See the assets to download this version and install."
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary by Sourcery

Update the CI workflows to change the release name, publish releases immediately, and ignore pushes to the 'release' branch in the build process.

CI:
- Update the publish workflow to change the release name from 'App' to 'Quilter' and set releases to be published immediately instead of as drafts.
- Modify the build workflow to ignore pushes to the 'release' branch.